### PR TITLE
Update 'AssetStreamingImagePoolSize' value just for o3de-demo-project + Loft Scene

### DIFF
--- a/Registry/atom_rpi.setregpatch
+++ b/Registry/atom_rpi.setregpatch
@@ -1,0 +1,3 @@
+[
+    { "op": "replace", "path": "/O3DE/Atom/RPI/Initialization/ImageSystemDescriptor/AssetStreamingImagePoolSize", "value": 3221225472 }
+]


### PR DESCRIPTION
Added setreg patch file to update 'AssetStreamingImagePoolSize' to accommodate Loft scene

Signed-off-by: Steve Pham <82231385+spham-amzn@users.noreply.github.com>