### PR TITLE
O3DE commit hash updated after GEMs camera API update

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Refer to the [O3DE System Requirements](https://www.o3de.org/docs/welcome-guide/
 This project has the following dependencies:
 
 - [O3DE](https://github.com/o3de/o3de)
-  -  Should work with `develop` branch and newest releases, but the project was tested with commit `#89ab3eae`.
+  -  Should work with `develop` branch and newest releases, but the project was tested with commit `#381a6e0f`.
 - [ROS2 Gem](https://github.com/RobotecAI/o3de-ros2-gem)
   - `develop` branch (the default) should work. The project was tested with version tag `0.3`.
   - ROS 2 (Galactic) itself is also required, see [Gem Requirements](https://github.com/RobotecAI/o3de-ros2-gem#requirements)  


### PR DESCRIPTION
**Content description** 
Due to the utilization of a [new camera capturing API in the ROS2 gem](https://github.com/RobotecAI/o3de-ros2-gem/pull/103), the o3de repository commit hash mentioned in the README file needed an update. ROS2 gem would not compile with the old hash anymore