### PR TITLE
Fix launcher errors and warnings

### DIFF
--- a/launch/config/config.rviz
+++ b/launch/config/config.rviz
@@ -239,7 +239,7 @@ Visualization Manager:
       Name: Current View
       Near Clip Distance: 0.009999999776482582
       Scale: 50.494564056396484
-      Target Frame: base_footprint
+      Target Frame: <Fixed Frame>
       Value: TopDownOrtho (rviz_default_plugins)
       X: 2.709298610687256
       Y: 3.506922721862793

--- a/launch/navigation.launch.py
+++ b/launch/navigation.launch.py
@@ -22,9 +22,7 @@ def generate_launch_description():
             package='rviz2',
             executable='rviz2',
             name='slam',
-            output={
-                'stdout': 'log',
-            },
+            output='log',
             arguments=[
                 '-d', str(pathlib.Path(__file__).parent.absolute().joinpath('config', 'config.rviz')),
             ]


### PR DESCRIPTION
1. Fix error launching the navigation stack:
   ```
   [ERROR] [launch]: Caught exception in launch (see debug for traceback): stdout is not a valid standard output config i.e. "screen", "log" or "both"
   ```
2. Fix warning when runninng rviz
    ```
    [rviz2-11] Warning: Invalid frame ID "base_footprint" passed to canTransform argument source_frame - frame does not exist
    [rviz2-11]          at line 93 in ./src/buffer_core.cpp
    ```

Signed-off-by: Steve Pham <82231385+spham-amzn@users.noreply.github.com>